### PR TITLE
make phoenix dependencies less constrained

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,11 +32,11 @@ defmodule LiveElements.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:phoenix, "~> 1.7.1"},
+      {:phoenix, ">= 1.7.1"},
       {:ex_doc, ">= 0.0.0"},
-      {:phoenix_live_view, "~> 0.18.15"},
+      {:phoenix_live_view, ">= 0.18.0"},
       {:jason, ">= 0.0.0"},
-      {:uuid, "~> 1.1" }
+      {:uuid, "~> 1.1"}
     ]
   end
 end


### PR DESCRIPTION
Previously, the `phoenix` and `phoenix_live_view` dependencies were locked to a specific minor version. If a downstream project uses a more recent version of these dependencies, they will not be able to use this library.
To that end, we use `>=` instead of `~>` to loosen these constraints.